### PR TITLE
support 0.107

### DIFF
--- a/packages/airx.yaml
+++ b/packages/airx.yaml
@@ -47,7 +47,6 @@ sensor:
 group:
   airx:
     name: Airx空气净化器
-    view: no
     entities:
       - fan.airx
       - sensor.airx_pm25


### PR DESCRIPTION
Groups - Groups are NOT being removed, but the configuration options, services, and service options related to the (previously deprecated and now removed) States UI are now removed in this release. This includes:

The view and control configuration options for a group.
The group.set_visibility service call
The control, visible, view options on the group.set service call
Please ensure your configuration and automations do not use these anymore. - (@frenck - #32021) (group docs)